### PR TITLE
Fix relative link, website is not markdown

### DIFF
--- a/content/docs/modes/bgp.md
+++ b/content/docs/modes/bgp.md
@@ -11,4 +11,4 @@ description: >
 
 When using kube-vip with BGP various bits of information are required, namely we require the credentials for the devices that will be handling the routing for the network. Most of this is passed in as part of the kube-vip configuration. In some environments kube-vip can use API calls in order to determine this information from the underlying infrastructure.
 
-To understand more look at the BGP section in the [Flags and Environment page](/content/docs/installation/flags.md) or the details should exist on a particular usage page.
+To understand more look at the BGP section in the [Flags and Environment page](/docs/installation/flags/) or the details should exist on a particular usage page.

--- a/content/docs/usage/k3s.md
+++ b/content/docs/usage/k3s.md
@@ -41,7 +41,7 @@ curl https://kube-vip.io/manifests/rbac.yaml > /var/lib/rancher/k3s/server/manif
 
 ## Step 3: Generate a kube-vip DaemonSet Manifest
 
-Refer to the [DaemonSet manifest generation documentation](/content/docs/installation/daemonset.md#generating-a-manifest) for the process to complete this step.
+Refer to the [DaemonSet manifest generation documentation](/docs/installation/daemonset/#generating-a-manifest) for the process to complete this step.
 
 Either store this generated manifest separately in the `/var/lib/rancher/k3s/server/manifests/` directory, or append to the existing RBAC manifest called `kube-vip-rbac.yaml`. As a general best practice, it is a cleaner approach to place all related resources into a single YAML file.
 


### PR DESCRIPTION
Fix this https://github.com/kube-vip/kube-vip/issues/525 again
Follow the real link from website this time
https://kube-vip.io/docs/installation/flags/
https://kube-vip.io/docs/installation/daemonset/#generating-a-manifest
