### PR TITLE
Updated RBAC with endpointslices

### DIFF
--- a/content/manifests/rbac.yaml
+++ b/content/manifests/rbac.yaml
@@ -23,6 +23,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["list", "get", "watch", "update", "create"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list","get","watch", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR adds endpointslices privileges to the RBAC manifest. This is required if [#720](https://github.com/kube-vip/kube-vip/pull/720) will be merged into `kube-vip`.