### PR TITLE
Fix for interface name in BGP example manifest

### DIFF
--- a/content/docs/installation/static.md
+++ b/content/docs/installation/static.md
@@ -182,7 +182,7 @@ spec:
     - name: port
       value: "6443"
     - name: vip_interface
-      value: ens192
+      value: lo
     - name: vip_cidr
       value: "32"
     - name: cp_enable


### PR DESCRIPTION
This is small but was confusing when I first encountered it. The `vip_interface` should be `lo` as documented above, where it says:

```shell
export INTERFACE=lo
```

Sorry if this is a nitpick, but it could clear up something for someone in the future.