### PR TITLE
Document admin.conf limitation for leader election

### DIFF
--- a/content/docs/installation/static.md
+++ b/content/docs/installation/static.md
@@ -143,6 +143,8 @@ spec:
 status: {}
 ```
 
+> Note: Since Kubernetes v1.29, the kubeadm bootstrap process has changed so that the `admin.conf` isn't usable immediately. This can be worked around by using the `super-admin.conf` for initialization and then switching to `admin.conf` when done. See [this issue](https://github.com/kube-vip/kube-vip/issues/684) for more details.
+
 ### BGP
 
 This configuration will create a manifest that starts kube-vip providing control plane VIP and Kubernetes Service management. Unlike ARP, all nodes in the BGP configuration will advertise virtual IP addresses.


### PR DESCRIPTION
This documents a critical limitation since Kubernetes v1.29 that prevents kube-vip from working with the admin.conf when leader election is used with a kubeadm bootstrap process.

Related to https://github.com/kube-vip/kube-vip/issues/684.
I think this is important to add directly in the docs because it is one of the first things new users will run into (myself included). I followed the ARP example and could not get it to work at all until I found the issue from 2023 describing exactly what I was facing. The workaround mentioned works well, but I also understand that this isn't something suitable for including directly as a recommendation.