### PR TITLE
make footer CLOMonitor compliant

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "kube-vip.io/"
 title = "kube-vip"
-copyright = "Copyright kube-vip a Series of LF Projects, LLC.<br><br>For website terms of use, trademark policy and other project policies please see <a href=\"https://lfprojects.org/policies/\" style=\"color: var(--theme);\">lfprojects.org/policies</a>."
+copyright = "Copyright © kube-vip a Series of LF Projects, LLC.<br><br>The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href=\"https://www.linuxfoundation.org/legal/trademark-usage\" style=\"color: var(--theme);\">Trademark Usage page</a>.<br><br>For website terms of use and other project policies please see <a href=\"https://lfprojects.org/policies/\" style=\"color: var(--theme);\">lfprojects.org/policies</a>."
 enableRobotsTXT = true
 # this example loads the theme as hugo module
 # comment out line below, and uncomment the line after it if you prefer to load the theme normally


### PR DESCRIPTION
The website footer was recently updated to add required CNCF website footer text - https://github.com/kube-vip/website/pull/69

However this footer is not compliant with CLOMonitor - https://clomonitor.io/docs/topics/checks/#trademark-disclaimer

This PR updates the footer text to make it CLOMonitor compliant.

Closes #38 