### PR TITLE
fix: service usage doucmentation

### DIFF
--- a/content/docs/usage/kubernetes-services.md
+++ b/content/docs/usage/kubernetes-services.md
@@ -169,17 +169,17 @@ $ curl externalIP:32380
 
 ### DDNS and DHCP
 
-Services can be configured to use DHCP by providing 'empty' addresses to `kube-vip.io/loadbalancerIP` annotation. For IPv4 the address is `0.0.0.0` and for IPv6 it is `::`.
+Services can be configured to use DHCP by providing 'empty' addresses to `kube-vip.io/loadbalancerIPs` annotation. For IPv4 the address is `0.0.0.0` and for IPv6 it is `::`.
 DualStack service can be configured by specifing those two addresses separated by comma.
 
 ```yaml
-kube-vip.io/loadbalancerIP: "0.0.0.0,::" # this will try to obtain both IPv4 and IPv6 addresses.
+kube-vip.io/loadbalancerIPs: "0.0.0.0,::" # this will try to obtain both IPv4 and IPv6 addresses.
 ```
 
 Services can also use DNS names to obtain IP address via DNS lookup:
 
 ```yaml
-kube-vip.io/loadbalancerIP: "service.example.com"
+kube-vip.io/loadbalancerIPs: "service.example.com"
 ```
 
 DNS names can be used with DDNS by enabling DDNS for the service using annotation:

--- a/content/docs/usage/kubernetes-services.md
+++ b/content/docs/usage/kubernetes-services.md
@@ -5,7 +5,7 @@ description: >
   Kubernetes services options
 ---
 
-When the services are enabled for kube-vip a [watcher](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) is enabled on all services that match the type `loadBalancer`. The "watcher" will only advertise a kubernetes service once the `metadata.annotations["kube-vip.io/loadbalancerIPs"]`(Since kube-vip 0.5.12) or `spec.loadBalancerIP` has been populated, which is the role performed by a cloud controller. Additionally kube-vip may ignore or act upon a service depending on various annotations.
+When the services are enabled for kube-vip a [watcher](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) is enabled on all services that match the type `loadBalancer`. The "watcher" will only advertise a kubernetes service once the `metadata.annotations["kube-vip.io/loadbalancerIPs"]` (Since kube-vip 0.5.12) or `spec.loadBalancerIP` has been populated, which is the role performed by a cloud controller. Additionally kube-vip may ignore or act upon a service depending on various annotations.
 
 ## Configure kube-vip to ignore a service
 


### PR DESCRIPTION
Fix documentation about service usage annotations : kube-vip.io/loadbalancerIPs