### PR TITLE
docs: document instance name for nftables egress isolation

### DIFF
--- a/content/docs/installation/flags.md
+++ b/content/docs/installation/flags.md
@@ -23,6 +23,8 @@ These flags are typically used in the kube-vip manifest generation process.
 |                     | `--controlplane`       | Enables kube-vip control plane functionality                          |                                                                                 |
 |                     | `--services`           | Enables kube-vip to watch services of type `LoadBalancer`             |                                                                                 |
 |                     | `--enableEndpointSlices`  | Enables use of `EndopintSlices` instead of `Endpoints`             |                                                                                 |
+| **Instance**        |                        |                                                                       |                                                                                 |
+|                     | `--instanceName`       | default `""`                                                          | Unique instance name; currently used to isolate nftables egress tables          |
 | **VIP Config**      |                        |                                                                       |                                                                                 |
 |                     | `--vip`                | `<IP Address>`                                                        | (deprecated)                                                                    |
 |                     | `--address`            | `<IP Address>` or `<DNS name>`                                        |                                                                                 |
@@ -95,6 +97,8 @@ Keep in mind Environment Variables always win against Flags.
 | **Mode**            |                       |                                                                                 |                                                                                 |
 |                     | `cp_enable`           | Enables kube-vip control plane functionality                                    |                                                                                 |
 |                     | `svc_enable`          | Enables kube-vip to watch Services of type `LoadBalancer`                       |                                                                                 |
+| **Instance**        |                       |                                                                                 |                                                                                 |
+|                     | `instance_name`       | default `""`                                                                    | Unique instance name; currently used to isolate nftables egress tables          |
 | **VIP Config**      |                       |                                                                                 |                                                                                 |
 |                     | `vip_arp`             | Enables ARP broadcasts from Leader                                              |                                                                                 |
 |                     | `bgp_enable`          | Enables BGP peering from kube-vip                                               |                                                                                 |
@@ -143,7 +147,7 @@ Keep in mind Environment Variables always win against Flags.
 |                     | `control_plane_health_check_failure_threshold` | default 3                                                  | Consecutive failures before BGP route withdrawal                                |
 |                     | `control_plane_health_check_ca_path` | Path to CA cert for HTTPS verification                               | Required when using HTTPS with a private CA                                     |
 | **Egress**          |                       |                                                                                 |                                                                                 |
-|                     | `EGRESS_CLEAN`        | Enables kube-vip to clean left over iptables rules                              |                                                                                 |
+|                     | `EGRESS_CLEAN`        | Cleans leftover egress rules and the configured nftables tables at startup      |                                                                                 |
 |                     | `egress_withnftables` | Uses nftables instead of iptables                                               |                                                                                 |
 | **Prometheus**      |                       |                                                                                 |                                                                                 |
 |                     | `prometheus_server`   | Default `:2112`                                                                 | Host and port for the Prometheus metrics HTTP server. Set to `""` to disable.   |

--- a/content/docs/troubleshooting/egress.md
+++ b/content/docs/troubleshooting/egress.md
@@ -40,6 +40,8 @@ More information about Calicos behaviour is available [here](https://docs.tigera
 
 In the event that kube-vip is being terminated, then it won't be able to clean up existing rules during shutdown. In order for kube-vip to clean those rules we can add the environment variable `EGRESS_CLEAN`, set to `true` to the kube-vip configuration. This will ensure that on startup kube-vip will remove any rules that have the comment `/* a3ViZS12aXAK=kube-vip */` (used to identify rules kube-vip manages). 
 
+When using internal nftables egress, `EGRESS_CLEAN` clears the nftables tables configured for the current kube-vip instance. If multiple kube-vip deployments run on the same nodes, assign each one a unique `instance_name` so that cleanup cannot affect another deployment. See [Isolating nftables egress tables](/docs/usage/egress/#isolating-nftables-egress-tables-for-multiple-kube-vip-instances).
+
 ## Finding the iptables rules
 
 In order to view the iptables rules created by kube-vip you may need to use the legacy iptables command, you can view the current configuration with `sudo iptables -v`. If `nf_tables` is listed then you will need to use `iptables-legacy` in order to view the correct rules.

--- a/content/docs/usage/egress.md
+++ b/content/docs/usage/egress.md
@@ -105,6 +105,27 @@ For a little more detail there is a blog post [here](https://thebsdbox.co.uk/202
 
 To enable Egress kube-vip requires `serviceElection` to be enabled, the Kubernetes service requires the below Egress annotation **and** it requires `externalTrafficPolicy` set to `Local`. 
 
+### Isolating nftables egress tables for multiple kube-vip instances
+
+By default, every kube-vip instance uses the nftables egress tables `kube_vip_v4` and `kube_vip_v6`. If multiple kube-vip deployments run on the same nodes, they would therefore share those tables. In particular, enabling `EGRESS_CLEAN` could allow one deployment to clear egress state belonging to another deployment.
+
+Set a unique instance name for each deployment that uses nftables egress. The value can be provided as an environment variable:
+
+```yaml
+env:
+  - name: instance_name
+    value: "release_a"
+```
+
+It can also be set with the `--instanceName release_a` flag or the `instanceName: "release_a"` configuration file field. kube-vip prefixes the value and appends the address family, so this example uses:
+
+- `kube_vip_release_a_v4`
+- `kube_vip_release_a_v6`
+
+An empty instance name retains the legacy `kube_vip_v4` and `kube_vip_v6` table names. Instance names may contain ASCII letters, digits, `.`, `-`, and `_`, and must not exceed 243 bytes.
+
+kube-vip stores the effective table base name in the managed Service annotation `kube-vip.io/egress-nftables-table`. When the instance name changes, active per-Service egress chains are migrated to the new tables. The instance name currently scopes nftables egress state only; other shared host resources must still be configured independently.
+
 ### Applying Egress rules only to certain destination ports
 
 To allow differentiation of traffic, in the event you would have multiple pods performing various egress.. we can apply rules that are specific on outbound traffic. So if we had a sip client that was sending traffic out to a remote host on port `5060` we would only rewrite the egress of that traffic particularly. This is done through annotations:

--- a/content/docs/usage/multi_tenancy.md
+++ b/content/docs/usage/multi_tenancy.md
@@ -90,3 +90,17 @@ By default prometheus will bind to port `2112`, this isn't normally a problem ho
         - --prometheusHTTPServer
         - ""
 ```
+
+### nftables egress conflicts
+
+Multiple kube-vip deployments running on the same nodes share the default nftables egress tables. If nftables egress is enabled, give each deployment a unique `instance_name`, especially when using `EGRESS_CLEAN`:
+
+```yaml
+env:
+  - name: instance_name
+    value: "finance"
+```
+
+The example above uses the `kube_vip_finance_v4` and `kube_vip_finance_v6` tables instead of the shared legacy tables. See the [Egress documentation](/docs/usage/egress/#isolating-nftables-egress-tables-for-multiple-kube-vip-instances) for the supported configuration methods, validation rules, and migration behaviour.
+
+`instance_name` currently isolates nftables egress state only. Namespace filters, load balancer classes, routing table IDs, Prometheus ports, and other shared resources still need to be configured separately for each deployment.


### PR DESCRIPTION
## What this adds

Documents the instance name introduced by kube-vip/kube-vip#1635 for isolating internal nftables egress state when multiple kube-vip deployments run on the same nodes.

The update covers:

- `--instanceName`, `instance_name`, and the `instanceName` config file field;
- derived table names, legacy defaults, allowed characters, and the 243-byte limit;
- the managed Service annotation and migration behavior when the instance name changes;
- nftables egress conflicts in multi-tenant deployments;
- the instance-scoped behavior of `EGRESS_CLEAN` in the troubleshooting and reference pages.

It also clarifies that the instance name currently scopes nftables egress state only; other shared host resources still require separate configuration.

## Validation

- `hugo v0.147.2 --gc --minify`
- `git diff --check`

Follow-up to kube-vip/kube-vip#1635.