### PR TITLE
docs: expand in-place kube-vip upgrade path

### DIFF
--- a/content/docs/upgrade/_index.md
+++ b/content/docs/upgrade/_index.md
@@ -2,7 +2,32 @@
 title: "Upgrade"
 weight: 20
 description: >
-  kube-vip version upgrade
+  Upgrade kube-vip on a running cluster without recreating the control plane.
 ---
 
-This section talks about upgrading version of kube-vip. It's crucial to keep kube-vip at latest release.
+Keep kube-vip on a current release. You can upgrade an existing cluster in place;
+you do **not** need to rebuild control-plane nodes or re-run `kubeadm init`.
+
+## What changes on upgrade
+
+Upgrades replace the kube-vip container image (and optionally regenerate the
+manifest when flags or defaults have changed between versions). Leader election
+handles the hand-off: when a kube-vip Pod restarts, another instance can take the
+VIP, then the upgraded instance rejoins election as usual.
+
+## Choose your install path
+
+| How kube-vip was installed | Upgrade guide |
+| --- | --- |
+| Static Pod under `/etc/kubernetes/manifests` (typical kubeadm) | [Upgrade using manifest](/docs/upgrade/manifest/) |
+| DaemonSet (K3s and similar) | Follow the DaemonSet steps on the [manifest upgrade](/docs/upgrade/manifest/) page |
+
+## Before you start
+
+1. Note the VIP, interface name, and feature flags you use today (ARP/BGP,
+   control plane, services, leader election). You will need the same values if
+   you regenerate the manifest.
+2. Pick a target version from the
+   [kube-vip releases](https://github.com/kube-vip/kube-vip/releases) page.
+3. For production clusters, upgrade one control-plane node at a time and confirm
+   the API server remains reachable on the VIP after each node.

--- a/content/docs/upgrade/manifest.md
+++ b/content/docs/upgrade/manifest.md
@@ -2,7 +2,86 @@
 title: "Upgrade using manifest"
 weight: 24
 description: >
-  kube-vip version upgrade using yaml
+  Upgrade static Pod or DaemonSet installs by refreshing the kube-vip manifest.
 ---
 
-As with most cases of kuberentes resources, substituting the value of image to desired version triggers the upgrade process of that resource. To upgrade kube-vip please edit the yaml file located at `/etc/kubernetes/manifests/kube-vip.yaml` and set the image version you want to upgrade to. This should simply restart the pods which in turn will restart the leader election and kube-vip will take over the VIP.
+There are two supported approaches. Prefer **regenerating** the manifest when
+moving across versions that added or renamed flags; a simple image-tag bump is
+enough for patch releases when your flags are unchanged.
+
+## Static Pod (kubeadm)
+
+Default path on each control-plane node: `/etc/kubernetes/manifests/kube-vip.yaml`.
+The kubelet restarts the static Pod when that file changes. No node reboot is
+required.
+
+### Option A - bump the image tag only
+
+Edit the manifest on **one** control-plane node and set the container image to
+the new tag (for example `ghcr.io/kube-vip/kube-vip:v0.8.0`). Save the file and
+wait until the kube-vip Pod is running again and the VIP still answers:
+
+```sh
+sudo sed -i 's#ghcr.io/kube-vip/kube-vip:.*#ghcr.io/kube-vip/kube-vip:v0.8.0#' \
+  /etc/kubernetes/manifests/kube-vip.yaml
+
+# confirm the static Pod restarted (name may include a random suffix)
+kubectl -n kube-system get pods -l app=kube-vip 2>/dev/null || \
+  kubectl -n kube-system get pods | grep kube-vip
+```
+
+Repeat on each remaining control-plane node.
+
+### Option B - regenerate the manifest (recommended across minor versions)
+
+Match the flags you use in production (see
+[static Pod installation](/docs/installation/static/)). Example ARP control-plane
++ services setup:
+
+```sh
+export VIP=<your-vip>
+export INTERFACE=<your-interface>
+export KVVERSION=v0.8.0   # or: $(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases/latest | jq -r .tag_name)
+
+alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:$KVVERSION"
+# containerd alternative:
+# alias kube-vip="ctr image pull ghcr.io/kube-vip/kube-vip:$KVVERSION; ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip"
+
+kube-vip manifest pod \
+  --interface "$INTERFACE" \
+  --address "$VIP" \
+  --controlplane \
+  --services \
+  --arp \
+  --leaderElection | sudo tee /etc/kubernetes/manifests/kube-vip.yaml
+```
+
+Apply the same regenerated file on every control-plane node (copy with `scp` or
+re-run the generator on each node). Leader election absorbs the rolling restart.
+
+## DaemonSet installs
+
+If kube-vip runs as a DaemonSet instead of a static Pod:
+
+1. Regenerate with `kube-vip manifest daemonset ...` using the same flags as
+   [DaemonSet installation](/docs/installation/daemonset/), **or** update the
+   image field in the live DaemonSet.
+2. Apply the manifest (`kubectl apply -f ...`). Kubernetes rolls the Pods;
+   watch with `kubectl -n kube-system rollout status ds/kube-vip` (name may
+   differ if you customized it).
+
+Keep the RBAC manifest current as well when release notes call for it:
+
+```sh
+kubectl apply -f https://kube-vip.io/manifests/rbac.yaml
+```
+
+## After upgrade
+
+- Confirm the VIP still reaches the API server: `kubectl cluster-info` or
+  `curl -k https://<VIP>:6443/livez`.
+- Check kube-vip logs on a control-plane node for leader election and ARP/BGP
+  errors.
+- If the Pod crash-loops, compare your regenerated flags with the previous
+  manifest; do not mix unrelated configuration changes into the same upgrade
+  step.


### PR DESCRIPTION
## Summary

Expands the Upgrade docs so operators can move between versions on a live cluster without rebuilding control planes:

- overview of what changes and how leader election handles hand-off
- static Pod: image-tag bump vs regenerating `kube-vip manifest pod`
- DaemonSet path and RBAC refresh
- post-upgrade VIP / API checks

Aligns with the maintainer guidance from kube-vip/kube-vip#499 (recreate/regenerate manifests; leader election handles the transition).

Fixes kube-vip/kube-vip#499